### PR TITLE
openscad: Add binary

### DIFF
--- a/Casks/openscad-snapshot.rb
+++ b/Casks/openscad-snapshot.rb
@@ -15,6 +15,7 @@ cask "openscad-snapshot" do
   conflicts_with cask: "openscad"
 
   app "OpenSCAD.app"
+  binary "#{appdir}/OpenSCAD.app/Contents/MacOS/OpenSCAD", target: "openscad"
 
   zap trash: [
     "~/Library/Caches/org.openscad.OpenSCAD",


### PR DESCRIPTION
## Description

Link the `openscad` binary analogous to [this PR in `homebrew-cask`](https://github.com/Homebrew/homebrew-cask/pull/162799) so it can be used as CLI.

## Verification

- [x] ~~The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).~~ This is a nightly snapshot and therefore possibly unstable. 
- [x] `brew audit --strict --cask --online openscad-snapshot` is error-free.
- [x] `brew style --fix openscad-snapshot` reports no offenses.
- [x] `openscad --version` works after installing the cask with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source openscad-snapshot`.

I followed [How to Open a Homebrew Pull Request — Homebrew Documentation](https://docs.brew.sh/How-To-Open-a-Homebrew-Pull-Request#create-your-pull-request-from-a-new-branch). `brew tests` failed around 50 tests. I don't think this change could have possibly caused them.

Furthermore `brew test openscad-snapshot` cannot find the formula. I assume the `test` command only works with `homebrew/core` then?
